### PR TITLE
removed register

### DIFF
--- a/include/krb5/krb5.h
+++ b/include/krb5/krb5.h
@@ -3563,7 +3563,7 @@ krb5_parse_name_flags(krb5_context context, const char *name,
  */
 krb5_error_code KRB5_CALLCONV
 krb5_unparse_name(krb5_context context, krb5_const_principal principal,
-                  register char **name);
+                  char **name);
 
 /**
  * Convert krb5_principal structure to string and length.
@@ -4386,7 +4386,7 @@ krb5_kt_add_entry(krb5_context context, krb5_keytab id, krb5_keytab_entry *entry
  */
 krb5_error_code KRB5_CALLCONV_WRONG
 krb5_principal2salt(krb5_context context,
-                    register krb5_const_principal pr, krb5_data *ret);
+                    krb5_const_principal pr, krb5_data *ret);
 /* librc.spec--see rcache.h */
 
 /* libcc.spec */
@@ -4727,7 +4727,7 @@ krb5_free_ticket(krb5_context context, krb5_ticket *val);
  * This function frees the contents of @a val and the structure itself.
  */
 void KRB5_CALLCONV
-krb5_free_error(krb5_context context, register krb5_error *val);
+krb5_free_error(krb5_context context, krb5_error *val);
 
 /**
  * Free a krb5_creds structure.
@@ -4760,7 +4760,7 @@ krb5_free_cred_contents(krb5_context context, krb5_creds *val);
  * This function frees the contents of @a val and the structure itself.
  */
 void KRB5_CALLCONV
-krb5_free_checksum(krb5_context context, register krb5_checksum *val);
+krb5_free_checksum(krb5_context context, krb5_checksum *val);
 
 /**
  * Free the contents of a krb5_checksum structure.
@@ -4771,7 +4771,7 @@ krb5_free_checksum(krb5_context context, register krb5_checksum *val);
  * This function frees the contents of @a val, but not the structure itself.
  */
 void KRB5_CALLCONV
-krb5_free_checksum_contents(krb5_context context, register krb5_checksum *val);
+krb5_free_checksum_contents(krb5_context context, krb5_checksum *val);
 
 /**
  * Free a krb5_keyblock structure.
@@ -4782,7 +4782,7 @@ krb5_free_checksum_contents(krb5_context context, register krb5_checksum *val);
  * This function frees the contents of @a val and the structure itself.
  */
 void KRB5_CALLCONV
-krb5_free_keyblock(krb5_context context, register krb5_keyblock *val);
+krb5_free_keyblock(krb5_context context, krb5_keyblock *val);
 
 /**
  * Free the contents of a krb5_keyblock structure.
@@ -4793,7 +4793,7 @@ krb5_free_keyblock(krb5_context context, register krb5_keyblock *val);
  * This function frees the contents of @a key, but not the structure itself.
  */
 void KRB5_CALLCONV
-krb5_free_keyblock_contents(krb5_context context, register krb5_keyblock *key);
+krb5_free_keyblock_contents(krb5_context context, krb5_keyblock *key);
 
 /**
  * Free a krb5_ap_rep_enc_part structure.
@@ -4909,7 +4909,7 @@ krb5_us_timeofday(krb5_context context,
  * Kerberos error codes
  */
 krb5_error_code KRB5_CALLCONV
-krb5_timeofday(krb5_context context, register krb5_timestamp *timeret);
+krb5_timeofday(krb5_context context, krb5_timestamp *timeret);
 
 /**
  * Check if a timestamp is within the allowed clock skew of the current time.


### PR DESCRIPTION
Removed register keyword from the krb.h header file.
register is deprecated in both ibm-clang and C++17

Upstream PR that removed register: https://github.com/krb5/krb5/commit/beeb2828945a41d86488e391ce440bacee0ec8a4